### PR TITLE
refactor(plenary): get rid of plenary as dependency for async http calls

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -38,19 +38,12 @@ jobs:
         run: |
           bash ./scripts/ci-install.sh
 
-      - name: Install plenary
-        run: make plenary
-
       - if: inputs.type == 'build'
         name: Compile parsers
-        env:
-          PLENARY: .test-deps/plenary.nvim
         run: $NVIM --clean -u scripts/minimal_init.lua -l scripts/install-parsers.lua --max-jobs=10
 
       - if: inputs.type == 'generate'
         name: Generate and compile parsers
-        env:
-          PLENARY: .test-deps/plenary.nvim
         run: $NVIM --clean -u scripts/minimal_init.lua -l scripts/install-parsers.lua --generate --max-jobs=2
 
       - name: Check parsers

--- a/Makefile
+++ b/Makefile
@@ -86,19 +86,16 @@ $(HLASSERT):
 	rm -rf $(HLASSERT_TARBALL)
 
 PLENTEST := $(DEPDIR)/plentest.nvim
-PLENARY := $(DEPDIR)/plenary.nvim
+
+.PHONY: plenary
+plenary:
+	@echo "plenary.nvim is no longer a dependency (uses vim.net.request in Neovim 0.12+)"
 
 .PHONY: plentest
 plentest: $(PLENTEST)
 
 $(PLENTEST):
 	git clone --filter=blob:none https://github.com/neovim-treesitter/plentest.nvim $(PLENTEST)
-
-.PHONY: plenary
-plenary: $(PLENARY)
-
-$(PLENARY):
-	git clone --filter=blob:none https://github.com/nvim-lua/plenary.nvim $(PLENARY)
 
 # Isolated parser install directory — blown away by `make clean`.
 # Both install-parsers.lua and minimal_init.lua read this env var so that
@@ -107,8 +104,8 @@ export TS_INSTALL_DIR ?= $(CURDIR)/$(DEPDIR)/parsers
 
 # Install all parsers into the isolated test directory.
 .PHONY: install-parsers
-install-parsers: $(NVIM) $(PLENARY)
-	PLENARY=$(PLENARY) $(NVIM_BIN) --headless --clean -u scripts/minimal_init.lua \
+install-parsers: $(NVIM)
+	$(NVIM_BIN) --headless --clean -u scripts/minimal_init.lua \
 		-l scripts/install-parsers.lua -- --max-jobs=8
 
 # actual test targets
@@ -140,8 +137,8 @@ checkquery: $(TSQUERYLS)
 	$(TSQUERYLS)/ts_query_ls check runtime/queries
 
 .PHONY: tests
-tests: $(NVIM) $(HLASSERT) $(PLENTEST) $(PLENARY)
-	HLASSERT=$(HLASSERT)/highlight-assertions PLENTEST=$(PLENTEST) PLENARY=$(PLENARY) \
+tests: $(NVIM) $(HLASSERT) $(PLENTEST)
+	HLASSERT=$(HLASSERT)/highlight-assertions PLENTEST=$(PLENTEST) \
 		TS_INSTALL_DIR=$(TS_INSTALL_DIR) \
 		$(NVIM_BIN) --headless --clean -u scripts/minimal_init.lua \
 		-c "lua require('plentest').test_directory('tests/$(TESTS)', { minimal_init = './scripts/minimal_init.lua' })"

--- a/README.md
+++ b/README.md
@@ -29,12 +29,10 @@ See the [neovim-treesitter org][org] for the full ecosystem.
 
 | Requirement | Version |
 |-------------|---------|
-| Neovim | 0.10.0 or later |
-| [nvim-lua/plenary.nvim][plenary] | latest |
+| Neovim | 0.12.0 or later |
 | [`tree-sitter` CLI][ts-cli] | 0.26.1 or later — install via your system package manager, **not npm** |
 | C compiler | see [cc requirements][cc] |
 
-[plenary]: https://github.com/nvim-lua/plenary.nvim
 [ts-cli]: https://github.com/tree-sitter/tree-sitter/blob/master/crates/cli/README.md
 [cc]: https://docs.rs/cc/latest/cc/#compile-time-requirements
 
@@ -51,7 +49,6 @@ See the [neovim-treesitter org][org] for the full ecosystem.
 ```lua
 {
   'nvim-treesitter/nvim-treesitter',
-  dependencies = { 'nvim-lua/plenary.nvim' },
   lazy = false,
   build = ':TSUpdate',
 }
@@ -62,8 +59,7 @@ See the [neovim-treesitter org][org] for the full ecosystem.
 
 ### Other plugin managers
 
-Ensure `nvim-lua/plenary.nvim` is installed as a dependency and add `:TSUpdate`
-as a post-install / post-update build step.
+Add `:TSUpdate` as a post-install / post-update build step.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,19 +38,8 @@ each one automatically.
 | `stylua-{arch}/` | `make stylua` | StyLua formatter |
 | `emmylua_check-{arch}/` | `make emmyluals` | EmmyLua static analyser |
 
-**plenary.nvim** — not in the Makefile yet. It is required by `lua/nvim-treesitter/install.lua`
-(via `plenary.curl`) and by the install tests. Clone it manually until a Makefile target is added:
-
-```bash
-git clone --filter=blob:none https://github.com/nvim-lua/plenary.nvim .test-deps/plenary.nvim
-```
-
-Then `scripts/minimal_init.lua` or the spec file itself must add it to the rtp. The
-`tests/install/install_spec.lua` adds it at the top of the file:
-
-```lua
-vim.opt.rtp:prepend(repo_root .. '/.test-deps/plenary.nvim')
-```
+**Note:** nvim-treesitter no longer depends on plenary.nvim. It uses Neovim's built-in
+`vim.net.request()` (available in Neovim 0.12+) for HTTP operations.
 
 ---
 
@@ -65,7 +54,7 @@ This is the `-u` init script passed to every headless run. It:
 5. Disables swapfile
 6. Sets up a `FileType` autocmd that starts treesitter and sets `indentexpr`
 
-If a test suite needs additional plugins (e.g. plenary), add them to the rtp either in
+If a test suite needs additional plugins, add them to the rtp either in
 `minimal_init.lua` or at the top of the spec file.
 
 ---
@@ -115,27 +104,25 @@ Tests `v:lua.require"nvim-treesitter".indentexpr()` for each language under `tes
 **Mocking strategy:**
 
 ```
-plenary.curl    → package.loaded['plenary.curl'] stub (placed before any require)
+vim.net.request → package.loaded['vim.net.request'] stub (placed before any require)
 vim.system      → per-test replacement; creates parser.so, simulates tar extraction
 registry.load   → wraps to call callback via vim.schedule
 version.refresh_all → injects versions into cache table, calls on_done via vim.schedule
 queries_resolver.resolve → no-op stub calling cb via vim.schedule
 ```
 
-The `plenary.curl` stub must be set in `package.loaded` **before** `registry.lua` is
-first `require`d, because `registry.lua` requires `plenary.curl` at module scope. The
-spec file does this at the very top.
+The `vim.net.request` stub must be set in `package.loaded` **before** any module that
+uses HTTP is first `require`d. The spec file does this at the very top.
 
 ---
 
 ## Writing New Specs
 
 1. Create `tests/<suite>/<name>_spec.lua`
-2. Use the plentest API: `describe`, `it`, `before_each`, `after_each`
+2. Use the plenltest API: `describe`, `it`, `before_each`, `after_each`
 3. Use `assert.True`, `assert.Falsy`, `assert.are.equal`, `assert.is.number`, etc.
-   (luassert, bundled with plentest)
-4. For async code, wrap the test body with `async(function() ... end)` from
-   `require('plenary.async')` if needed — or use `vim.wait` with a done flag.
+   (luassert, bundled with plenltest)
+4. For async code, use `vim.wait` with a done flag.
 5. Run with `make tests TESTS=<suite>`
 
 Example skeleton:

--- a/lua/nvim-treesitter/hosts.lua
+++ b/lua/nvim-treesitter/hosts.lua
@@ -1,12 +1,10 @@
 -- lua/nvim-treesitter/hosts.lua
 -- Vendored host adapter for version discovery.
 -- Originally derived from treesitter-parser-registry/lua/treesitter-registry/hosts.lua
--- Requires: nvim-lua/plenary.nvim
 --
 -- Git host adapters: version-check APIs + tarball/raw-file URL construction.
 --
--- Vendored copy of treesitter-registry/hosts.lua, patched to use
--- plenary.curl instead of raw vim.system curl invocations.
+-- Vendored copy of treesitter-registry/hosts.lua, uses vim.net.request for HTTP.
 --
 -- Version check strategy per host:
 --   github.com  → GitHub REST API (releases/tags endpoints, no auth needed for
@@ -32,27 +30,30 @@ local function owner_repo(url)
   return owner, repo
 end
 
---- HTTP GET via plenary.curl; calls callback(body, err).
+--- HTTP GET via vim.net.request; calls callback(body, err).
 ---@param url      string
 ---@param headers  table<string,string>?  header key→value pairs
 ---@param callback fun(body: string?, err: string?)
 local function http_get(url, headers, callback)
-  local curl = require('plenary.curl')
-  curl.get(url, {
-    headers = headers or {},
-    timeout = 10000,
-    callback = vim.schedule_wrap(function(r)
-      if r.status and r.status >= 200 and r.status < 300 then
-        callback(r.body, nil)
-      else
-        local err = 'HTTP ' .. tostring(r.status or 'unknown')
-        if r.body and r.body ~= '' then
-          err = err .. ': ' .. r.body
-        end
+  vim.net.request(
+    url,
+    { headers = headers or {}, retry = 3 },
+    vim.schedule_wrap(function(err, res)
+      if err then
         callback(nil, err)
+      elseif res and res.status >= 200 and res.status < 300 then
+        callback(res.body, nil)
+      else
+        local status = res and res.status or 'unknown'
+        local body = res and res.body or ''
+        local http_err = 'HTTP ' .. tostring(status)
+        if body and body ~= '' then
+          http_err = http_err .. ': ' .. body
+        end
+        callback(nil, http_err)
       end
-    end),
-  })
+    end)
+  )
 end
 
 --- Parse the latest semver tag from a list of tag objects.

--- a/lua/nvim-treesitter/hosts.lua
+++ b/lua/nvim-treesitter/hosts.lua
@@ -41,7 +41,8 @@ local function http_get(url, headers, callback)
     vim.schedule_wrap(function(err, res)
       if err then
         callback(nil, err)
-      elseif res and res.status >= 200 and res.status < 300 then
+        -- Check body instead of status since status may be nil when body is returned
+      elseif res and res.body then
         callback(res.body, nil)
       else
         local status = res and res.status or 'unknown'
@@ -50,7 +51,7 @@ local function http_get(url, headers, callback)
         if body and body ~= '' then
           http_err = http_err .. ': ' .. body
         end
-        callback(nil, http_err)
+        callback(nil, http_err or 'empty response')
       end
     end)
   )
@@ -335,6 +336,7 @@ end
 function generic.tarball_url(_url, _ref)
   return nil
 end
+
 function generic.raw_url(_url, _ref, _path)
   return nil
 end

--- a/lua/nvim-treesitter/install.lua
+++ b/lua/nvim-treesitter/install.lua
@@ -18,7 +18,7 @@
 ---                                   M.get_installed, M.set_installed
 ---   nvim-treesitter.queries_resolver M.resolve(lang, install_dir, cb)
 ---
---- HTTP: plenary.curl (never raw curl / vim.system for HTTP)
+--- HTTP: vim.net.request (Neovim 0.12+)
 --- Build: vim.system (tree-sitter CLI)
 
 local fn = vim.fn
@@ -150,9 +150,8 @@ local function system(cmd, opts)
   return r
 end
 
--- ── plenary.curl wrapper ──────────────────────────────────────────────────────
--- All HTTP downloads go through here.  plenary.curl is callback-based so we
--- wrap it with a.awrap to make it await-able.
+-- ── vim.net.request wrapper ────────────────────────────────────────────────────
+-- All HTTP downloads go through here. Uses vim.net.request for async downloads.
 
 ---@async
 ---@param url string
@@ -160,31 +159,22 @@ end
 ---@return { status: integer, body: string }? result, string? err
 local function curl_download(url, output_path)
   log.trace('curl_download %s -> %s', url, output_path)
-  local curl = require('plenary.curl')
-  local raw_args = { '-L', '--retry', '3', '--fail', '--show-error' }
-  -- GitHub API tarball endpoint needs the Accept header so the API returns a
-  -- 302 redirect to the pre-signed codeload URL instead of JSON metadata.
-  -- NOTE: Do NOT send Authorization here.  The GITHUB_TOKEN in Actions is an
-  -- installation token scoped to the running repo; curl -L forwards it to
-  -- codeload.github.com on the redirect, and codeload returns 200 HTML (not
-  -- gzip) for tokens that don't cover the target repo.  Public repos don't
-  -- need auth at all, so omitting it is both simpler and correct.
+  local headers = {}
   if url:match('api%.github%.com') then
-    raw_args[#raw_args + 1] = '-H'
-    raw_args[#raw_args + 1] = 'Accept: application/vnd.github+json'
+    headers['Accept'] = 'application/vnd.github+json'
   end
   local result, err = a.await(1, function(cb)
-    curl.get(url, {
-      output = output_path,
-      -- follow redirects, retry on transient failures
-      raw = raw_args,
-      callback = function(res)
-        cb(res, nil)
-      end,
-      on_error = function(e)
-        cb(nil, tostring(e))
-      end,
-    })
+    vim.net.request(url, {
+      outpath = output_path,
+      headers = headers,
+      retry = 3,
+    }, function(req_err)
+      if req_err then
+        cb(nil, req_err)
+      else
+        cb({ status = 200 }, nil)
+      end
+    end)
   end)
   return result, err
 end
@@ -205,7 +195,7 @@ local function do_download_tarball(logger, tarball_url, project_name, cache_dir,
 
   local tarball_path = fs.joinpath(cache_dir, project_name .. '.tar.gz')
 
-  do -- Download via plenary.curl
+  do -- Download via vim.net.request
     logger:info('Downloading %s...', project_name)
     local _, err = curl_download(tarball_url, tarball_path)
     if err then
@@ -949,7 +939,7 @@ M.install = a.async(function(languages, opts)
       local tasks = {} ---@type async.TaskFun[]
       for _, lang in ipairs(batch) do
         total = total + 1
-        tasks[#tasks + 1] = a.async(--[[@async]] function()
+        tasks[#tasks + 1] = a.async( --[[@async]] function()
           a.schedule()
           local ok = install_lang(
             lang,
@@ -1075,7 +1065,7 @@ M.update = a.async(function(languages, opts)
     local entry = local_parsers_upd[lang] or registry.get(lang)
     if entry then
       local versions = (cache.parsers and cache.parsers[lang]) or {}
-      tasks[#tasks + 1] = a.async(--[[@async]] function()
+      tasks[#tasks + 1] = a.async( --[[@async]] function()
         a.schedule()
         local ok = install_lang(lang, entry, versions, install_dir, cache_dir, true, opts)
         if ok then
@@ -1126,7 +1116,7 @@ M.uninstall = a.async(function(languages, opts)
       local parser = fs.joinpath(parser_dir, lang) .. '.so'
       local queries = fs.joinpath(query_dir, lang)
 
-      tasks[#tasks + 1] = a.async(--[[@async]] function()
+      tasks[#tasks + 1] = a.async( --[[@async]] function()
         local had_err = false
 
         -- Remove parser .so

--- a/lua/nvim-treesitter/registry.lua
+++ b/lua/nvim-treesitter/registry.lua
@@ -2,7 +2,7 @@
 -- Loads the treesitter-parser-registry JSON and exposes a simple get/load API.
 --
 -- The registry fetch + cache logic from treesitter-registry.lua is vendored
--- inline so this module has no external runtime dependency beyond plenary.curl.
+-- inline so this module has no external runtime dependencies.
 --
 -- Registry JSON structure per entry:
 --   {
@@ -120,19 +120,18 @@ function M.load(callback, opts)
   end
 
   -- ── Fetch a fresh copy ──────────────────────────────────────────────────
-  local curl = require('plenary.curl')
-  curl.get(REGISTRY_URL, {
-    headers = { accept = 'application/json' },
-    timeout = 15000,
-    callback = vim.schedule_wrap(function(response)
-      if response.status ~= 200 then
+  vim.net.request(
+    REGISTRY_URL,
+    { headers = { accept = 'application/json' }, retry = 3 },
+    vim.schedule_wrap(function(err, response)
+      if err or (response.status ~= 200) then
         -- Stale fallback — better than nothing
         local rok, lines = pcall(vim.fn.readfile, rp)
         local data = rok and decode_lines(lines) or nil
         if data then
           vim.notify(
             'nvim-treesitter: registry fetch failed (HTTP '
-              .. tostring(response.status)
+              .. tostring(response and response.status or 'unknown')
               .. '), using stale cache',
             vim.log.levels.WARN
           )
@@ -157,8 +156,8 @@ function M.load(callback, opts)
       data['$schema'] = nil
       M.loaded = data
       callback(data, nil)
-    end),
-  })
+    end)
+  )
 end
 
 return M

--- a/lua/nvim-treesitter/registry.lua
+++ b/lua/nvim-treesitter/registry.lua
@@ -124,10 +124,11 @@ function M.load(callback, opts)
     REGISTRY_URL,
     { headers = { accept = 'application/json' }, retry = 3 },
     vim.schedule_wrap(function(err, response)
-      if err or (response.status ~= 200) then
+      -- Check body instead of status since status may be nil when body is returned
+      if err or not response or not response.body then
         -- Stale fallback — better than nothing
-        local rok, lines = pcall(vim.fn.readfile, rp)
-        local data = rok and decode_lines(lines) or nil
+        local rok, cached = pcall(vim.fn.readfile, rp)
+        local data = rok and decode_lines(cached) or nil
         if data then
           vim.notify(
             'nvim-treesitter: registry fetch failed (HTTP '

--- a/lua/nvim-treesitter/version.lua
+++ b/lua/nvim-treesitter/version.lua
@@ -3,7 +3,7 @@
 --
 -- Uses the vendored hosts adapter at:
 --   lua/nvim-treesitter/hosts.lua
--- which itself uses plenary.curl for all HTTP traffic.
+-- which uses vim.net.request for HTTP traffic.
 --
 -- Public API:
 --   M.latest_parser(lang, source, callback)

--- a/plugin/filetypes.lua
+++ b/plugin/filetypes.lua
@@ -74,8 +74,8 @@ end
 -- Additionally register any filetype mappings declared in registry entries.
 -- Registry loading is asynchronous; mappings that duplicate the static table
 -- above are harmless (register is idempotent).
--- Use pcall so that a missing registry module (e.g. plenary not in rtp yet)
--- does not prevent the static registrations above from taking effect.
+-- Use pcall so that a missing registry module does not prevent the static
+-- registrations above from taking effect.
 local ok, registry = pcall(require, 'nvim-treesitter.registry')
 if ok then
   registry.load(function(reg)

--- a/plugin/nvim-treesitter.lua
+++ b/plugin/nvim-treesitter.lua
@@ -4,9 +4,6 @@
 -- Defines all user-facing commands and wires them to the new modular
 -- install.lua API.
 --
--- Requires:
---   nvim-lua/plenary.nvim  (used by install.lua for HTTP via plenary.curl)
---
 -- Commands:
 --   :TSInstall[!] {lang...}    install; bang = force reinstall
 --   :TSUpdate[!] [{lang...}]   update installed; bang = bypass version cache

--- a/tests/install/install_spec.lua
+++ b/tests/install/install_spec.lua
@@ -17,8 +17,8 @@
 --
 -- Mocking strategy
 -- ────────────────
--- * plenary.curl   — stubbed in package.loaded at file top so registry.lua
---                    never sees a missing module.
+-- * vim.net.request — stubbed in package.loaded at file top so modules
+--                    never see a missing module.
 -- * nvim-treesitter.registry — loaded fresh after stub; M.loaded injected
 --                    per-test; M.load wrapped to call cb via vim.schedule.
 -- * nvim-treesitter.version — refresh_all replaced per-test; calls on_done
@@ -30,32 +30,30 @@
 --                    lose the entry.
 -- * queries_resolver.resolve — no-op stub (calls callback via vim.schedule).
 
--- ── add plenary.nvim to rtp (provides luassert) ──────────────────────────────
-do
-  local repo_root = vim.fn.fnamemodify(debug.getinfo(1, 'S').source:sub(2), ':p:h:h:h')
-  vim.opt.rtp:prepend(repo_root .. '/.test-deps/plenary.nvim')
-end
-
--- ── stub plenary.curl BEFORE registry.lua can require it ─────────────────────
--- registry.lua does `local curl = require('plenary.curl')` at module scope.
--- We place a stub in package.loaded before any require() for it can run.
-package.loaded['plenary.curl'] = {
-  get = function(_url, opts)
-    if opts and opts.output then
-      vim.fn.mkdir(vim.fn.fnamemodify(opts.output, ':h'), 'p')
-      local f = io.open(opts.output, 'w')
+-- ── stub vim.net.request BEFORE modules that use it can require it ─────────────
+-- modules use `vim.net.request()` at runtime, not require time, so we can
+-- inject a stub directly in package.loaded['vim.net'] or wrap the function.
+local curl_calls = 0
+local function make_vim_net_stub()
+  return function(url, opts, callback)
+    curl_calls = curl_calls + 1
+    if opts and opts.outpath then
+      vim.fn.mkdir(vim.fn.fnamemodify(opts.outpath, ':h'), 'p')
+      local f = io.open(opts.outpath, 'w')
       if f then
         f:write('fake tarball')
         f:close()
       end
     end
-    -- Must be asynchronous — see async machinery notes in file header
     vim.schedule(function()
-      if opts and opts.callback then
-        opts.callback({ status = 200, body = '' })
+      if callback then
+        callback(nil, { status = 200, body = '' })
       end
     end)
-  end,
+  end
+end
+package.loaded['vim.net'] = {
+  request = make_vim_net_stub(),
 }
 
 -- Clear any partially-loaded (broken) registry module so it re-requires cleanly
@@ -357,16 +355,17 @@ local function setup(ctx)
   ctx.orig_system = vim.system
   vim.system = make_system_stub()
 
-  -- 3. ensure plenary.curl stub is still in place (may be evicted between tests)
-  package.loaded['plenary.curl'] = {
-    get = function(_url, opts)
-      if opts and opts.output then
-        mkdir_p(vim.fn.fnamemodify(opts.output, ':h'))
-        write_file(opts.output, 'fake tarball')
+  -- 3. ensure vim.net.request stub is still in place (may be evicted between tests)
+  package.loaded['vim.net'] = {
+    request = function(url, opts, callback)
+      curl_calls = curl_calls + 1
+      if opts and opts.outpath then
+        mkdir_p(vim.fn.fnamemodify(opts.outpath, ':h'))
+        write_file(opts.outpath, 'fake tarball')
       end
       vim.schedule(function()
-        if opts and opts.callback then
-          opts.callback({ status = 200, body = '' })
+        if callback then
+          callback(nil, { status = 200, body = '' })
         end
       end)
     end,
@@ -730,18 +729,18 @@ describe('install external_queries', function()
   end)
 
   it('installs parser and queries, writing both versions to cache', function()
-    -- Track curl download calls
+    -- Track vim.net.request calls
     local curl_calls = 0
-    package.loaded['plenary.curl'] = {
-      get = function(_url, opts)
+    package.loaded['vim.net'] = {
+      request = function(url, opts, callback)
         curl_calls = curl_calls + 1
-        if opts and opts.output then
-          mkdir_p(vim.fn.fnamemodify(opts.output, ':h'))
-          write_file(opts.output, 'fake tarball')
+        if opts and opts.outpath then
+          mkdir_p(vim.fn.fnamemodify(opts.outpath, ':h'))
+          write_file(opts.outpath, 'fake tarball')
         end
         vim.schedule(function()
-          if opts and opts.callback then
-            opts.callback({ status = 200, body = '' })
+          if callback then
+            callback(nil, { status = 200, body = '' })
           end
         end)
       end,
@@ -797,7 +796,7 @@ describe('install external_queries', function()
     -- Both parser tarball AND queries tarball downloads must happen (>= 2 curl calls)
     assert.True(
       curl_calls >= 2,
-      'plenary.curl.get must be called at least twice (parser + queries tarballs)'
+      'vim.net.request must be called at least twice (parser + queries tarballs)'
     )
   end)
 end)
@@ -863,16 +862,16 @@ describe('install queries_only', function()
     local build_calls = 0
     local curl_calls = 0
 
-    package.loaded['plenary.curl'] = {
-      get = function(_url, opts)
+    package.loaded['vim.net'] = {
+      request = function(url, opts, callback)
         curl_calls = curl_calls + 1
-        if opts and opts.output then
-          mkdir_p(vim.fn.fnamemodify(opts.output, ':h'))
-          write_file(opts.output, 'fake tarball')
+        if opts and opts.outpath then
+          mkdir_p(vim.fn.fnamemodify(opts.outpath, ':h'))
+          write_file(opts.outpath, 'fake tarball')
         end
         vim.schedule(function()
-          if opts and opts.callback then
-            opts.callback({ status = 200, body = '' })
+          if callback then
+            callback(nil, { status = 200, body = '' })
           end
         end)
       end,
@@ -932,7 +931,7 @@ describe('install queries_only', function()
     )
 
     -- At least one curl call for the queries tarball download
-    assert.True(curl_calls > 0, 'plenary.curl.get must be called for the queries tarball')
+    assert.True(curl_calls > 0, 'vim.net.request must be called for the queries tarball')
   end)
 end)
 
@@ -959,8 +958,8 @@ end)
 -- NOTE: the field for the remote URL is `source.url` (not `source.parser_url`) — this
 -- matches the field name used in the current install.lua implementation.
 --
--- For type='local' the install pipeline calls `do_compile` in place (no curl).
--- For type='self_contained' the pipeline downloads via plenary.curl then compiles.
+-- For type='local' the install pipeline calls `do_compile` in place (no HTTP).
+-- For type='self_contained' the pipeline downloads via vim.net.request then compiles.
 -- ─────────────────────────────────────────────────────────────────────────────
 
 -- Fake language names for local_parsers tests — distinct from the LANG constant
@@ -1053,20 +1052,18 @@ describe('local_parsers type=local', function()
     teardown(ctx)
   end)
 
-  it('installs from local path and copies queries; never calls curl', function()
-    -- Track whether plenary.curl.get was called
+  it('installs from local path and copies queries; never calls vim.net.request', function()
+    -- Track whether vim.net.request was called
     local curl_calls = 0
-    package.loaded['plenary.curl'] = vim.tbl_extend('force', package.loaded['plenary.curl'], {
-      get = function(_url, opts)
-        curl_calls = curl_calls + 1
-        -- Still behave like the stub so the pipeline does not stall
-        vim.schedule(function()
-          if opts and opts.callback then
-            opts.callback({ status = 200, body = '' })
-          end
-        end)
-      end,
-    })
+    local orig_request = package.loaded['vim.net'].request
+    package.loaded['vim.net'].request = function(url, opts, callback)
+      curl_calls = curl_calls + 1
+      vim.schedule(function()
+        if callback then
+          callback(nil, { status = 200, body = '' })
+        end
+      end)
+    end
 
     -- Wrap vim.system to count tree-sitter build calls; also create parser.so
     -- in the *local source dir* (where do_install_parser will look for it).
@@ -1106,8 +1103,8 @@ describe('local_parsers type=local', function()
     -- tree-sitter build must have been called exactly once
     assert.True(build_calls > 0, 'tree-sitter build must run for type=local')
 
-    -- plenary.curl.get must NOT have been called for a local type
-    eq(0, curl_calls, 'plenary.curl.get must not be called for type=local')
+    -- vim.net.request must NOT have been called for a local type
+    eq(0, curl_calls, 'vim.net.request must not be called for type=local')
   end)
 end)
 
@@ -1149,24 +1146,22 @@ describe('local_parsers type=self_contained', function()
     teardown(ctx)
   end)
 
-  it('fetches from URL via plenary.curl and creates parser .so', function()
+  it('fetches from URL via vim.net.request and creates parser .so', function()
     local curl_calls = 0
-    local orig_curl_get = package.loaded['plenary.curl'].get
-    package.loaded['plenary.curl'] = {
-      get = function(url, opts)
-        curl_calls = curl_calls + 1
-        -- Write a fake tarball so the extraction step has a file
-        if opts and opts.output then
-          mkdir_p(vim.fn.fnamemodify(opts.output, ':h'))
-          write_file(opts.output, 'fake tarball')
+    local orig_request = package.loaded['vim.net'].request
+    package.loaded['vim.net'].request = function(url, opts, callback)
+      curl_calls = curl_calls + 1
+      -- Write a fake tarball so the extraction step has a file
+      if opts and opts.outpath then
+        mkdir_p(vim.fn.fnamemodify(opts.outpath, ':h'))
+        write_file(opts.outpath, 'fake tarball')
+      end
+      vim.schedule(function()
+        if callback then
+          callback(nil, { status = 200, body = '' })
         end
-        vim.schedule(function()
-          if opts and opts.callback then
-            opts.callback({ status = 200, body = '' })
-          end
-        end)
-      end,
-    }
+      end)
+    end
 
     -- The system stub already creates parser.so in cwd on 'tree-sitter build'
     -- and a fake extracted directory on 'tar'.  The queries_path 'nvim-queries'
@@ -1212,8 +1207,8 @@ describe('local_parsers type=self_contained', function()
       'parser.so must exist in install_dir after self_contained install'
     )
 
-    -- plenary.curl.get must have been called (this is NOT a local-path install)
-    assert.True(curl_calls > 0, 'plenary.curl.get must be called for type=self_contained')
+    -- vim.net.request must have been called (this is NOT a local-path install)
+    assert.True(curl_calls > 0, 'vim.net.request must be called for type=self_contained')
 
     -- tree-sitter build must have been called
     assert.True(build_calls > 0, 'tree-sitter build must run for type=self_contained')
@@ -1291,18 +1286,16 @@ describe('local_parsers overrides registry', function()
       return base_stub(cmd, opts, on_exit)
     end
 
-    -- Track curl calls — they should NOT happen for type=local
+    -- Track vim.net.request calls — they should NOT happen for type=local
     local curl_calls = 0
-    package.loaded['plenary.curl'] = {
-      get = function(_url, opts)
-        curl_calls = curl_calls + 1
-        vim.schedule(function()
-          if opts and opts.callback then
-            opts.callback({ status = 200, body = '' })
-          end
-        end)
-      end,
-    }
+    package.loaded['vim.net'].request = function(url, opts, callback)
+      curl_calls = curl_calls + 1
+      vim.schedule(function()
+        if callback then
+          callback(nil, { status = 200, body = '' })
+        end
+      end)
+    end
 
     -- stub version.refresh_all for LOCAL_LANG3
     local version_mod = require('nvim-treesitter.version')
@@ -1324,7 +1317,7 @@ describe('local_parsers overrides registry', function()
     assert.True(ok, 'install should succeed when local_parsers overrides registry')
 
     -- No curl call — the local_parsers entry (type=local) was used, not the registry URL
-    eq(0, curl_calls, 'plenary.curl.get must not be called when local_parsers entry is type=local')
+    eq(0, curl_calls, 'vim.net.request must not be called when local_parsers entry is type=local')
 
     -- At least one tree-sitter build call must have used local_src_dir3 as cwd
     local used_local_path = false

--- a/tests/install/local_parsers_spec.lua
+++ b/tests/install/local_parsers_spec.lua
@@ -5,24 +5,20 @@
 --
 -- Setup is identical to install_spec.lua.
 
-do
-  local repo_root = vim.fn.fnamemodify(debug.getinfo(1, 'S').source:sub(2), ':p:h:h:h')
-  vim.opt.rtp:prepend(repo_root .. '/.test-deps/plenary.nvim')
-end
-
-package.loaded['plenary.curl'] = {
-  get = function(_url, opts)
-    if opts and opts.output then
-      vim.fn.mkdir(vim.fn.fnamemodify(opts.output, ':h'), 'p')
-      local f = io.open(opts.output, 'w')
+-- Stub vim.net.request for testing HTTP calls
+package.loaded['vim.net'] = {
+  request = function(url, opts, callback)
+    if opts and opts.outpath then
+      vim.fn.mkdir(vim.fn.fnamemodify(opts.outpath, ':h'), 'p')
+      local f = io.open(opts.outpath, 'w')
       if f then
         f:write('fake tarball')
         f:close()
       end
     end
     vim.schedule(function()
-      if opts and opts.callback then
-        opts.callback({ status = 200, body = '' })
+      if callback then
+        callback(nil, { status = 200, body = '' })
       end
     end)
   end,
@@ -145,15 +141,15 @@ local function setup(ctx)
   ctx.orig_system = vim.system
   vim.system = make_system_stub()
 
-  package.loaded['plenary.curl'] = {
-    get = function(_url, opts)
-      if opts and opts.output then
-        mkdir_p(vim.fn.fnamemodify(opts.output, ':h'))
-        write_file(opts.output, 'fake tarball')
+  package.loaded['vim.net'] = {
+    request = function(url, opts, callback)
+      if opts and opts.outpath then
+        mkdir_p(vim.fn.fnamemodify(opts.outpath, ':h'))
+        write_file(opts.outpath, 'fake tarball')
       end
       vim.schedule(function()
-        if opts and opts.callback then
-          opts.callback({ status = 200, body = '' })
+        if callback then
+          callback(nil, { status = 200, body = '' })
         end
       end)
     end,
@@ -266,18 +262,17 @@ describe('local_parsers type=local', function()
     teardown(ctx)
   end)
 
-  it('installs from local path and copies queries; never calls curl', function()
+  it('installs from local path and copies queries; never calls vim.net.request', function()
     local curl_calls = 0
-    package.loaded['plenary.curl'] = vim.tbl_extend('force', package.loaded['plenary.curl'], {
-      get = function(_url, opts)
-        curl_calls = curl_calls + 1
-        vim.schedule(function()
-          if opts and opts.callback then
-            opts.callback({ status = 200, body = '' })
-          end
-        end)
-      end,
-    })
+    local orig_request = package.loaded['vim.net'].request
+    package.loaded['vim.net'].request = function(url, opts, callback)
+      curl_calls = curl_calls + 1
+      vim.schedule(function()
+        if callback then
+          callback(nil, { status = 200, body = '' })
+        end
+      end)
+    end
 
     local build_calls = 0
     local base_stub = make_system_stub()
@@ -310,7 +305,7 @@ describe('local_parsers type=local', function()
     )
 
     assert.True(build_calls > 0, 'tree-sitter build must run for type=local')
-    eq(0, curl_calls, 'plenary.curl.get must not be called for type=local')
+    eq(0, curl_calls, 'vim.net.request must not be called for type=local')
   end)
 end)
 
@@ -357,22 +352,20 @@ describe('local_parsers type=self_contained', function()
     teardown(ctx)
   end)
 
-  it('fetches from URL via plenary.curl and creates parser .so', function()
+  it('fetches from URL via vim.net.request and creates parser .so', function()
     local curl_calls = 0
-    package.loaded['plenary.curl'] = {
-      get = function(_url, opts)
-        curl_calls = curl_calls + 1
-        if opts and opts.output then
-          mkdir_p(vim.fn.fnamemodify(opts.output, ':h'))
-          write_file(opts.output, 'fake tarball')
+    package.loaded['vim.net'].request = function(url, opts, callback)
+      curl_calls = curl_calls + 1
+      if opts and opts.outpath then
+        mkdir_p(vim.fn.fnamemodify(opts.outpath, ':h'))
+        write_file(opts.outpath, 'fake tarball')
+      end
+      vim.schedule(function()
+        if callback then
+          callback(nil, { status = 200, body = '' })
         end
-        vim.schedule(function()
-          if opts and opts.callback then
-            opts.callback({ status = 200, body = '' })
-          end
-        end)
-      end,
-    }
+      end)
+    end
 
     local build_calls = 0
     local base_stub = make_system_stub()
@@ -413,7 +406,7 @@ describe('local_parsers type=self_contained', function()
       'parser.so must exist in install_dir after self_contained install'
     )
 
-    assert.True(curl_calls > 0, 'plenary.curl.get must be called for type=self_contained')
+    assert.True(curl_calls > 0, 'vim.net.request must be called for type=self_contained')
 
     assert.True(build_calls > 0, 'tree-sitter build must run for type=self_contained')
   end)
@@ -476,16 +469,14 @@ describe('local_parsers overrides registry', function()
     end
 
     local curl_calls = 0
-    package.loaded['plenary.curl'] = {
-      get = function(_url, opts)
-        curl_calls = curl_calls + 1
-        vim.schedule(function()
-          if opts and opts.callback then
-            opts.callback({ status = 200, body = '' })
-          end
-        end)
-      end,
-    }
+    package.loaded['vim.net'].request = function(url, opts, callback)
+      curl_calls = curl_calls + 1
+      vim.schedule(function()
+        if callback then
+          callback(nil, { status = 200, body = '' })
+        end
+      end)
+    end
 
     local version_mod = require('nvim-treesitter.version')
     local orig_refresh = version_mod.refresh_all
@@ -507,7 +498,7 @@ describe('local_parsers overrides registry', function()
 
     assert.True(ok, 'install should succeed when local_parsers overrides registry')
 
-    eq(0, curl_calls, 'plenary.curl.get must not be called when local_parsers entry is type=local')
+    eq(0, curl_calls, 'vim.net.request must not be called when local_parsers entry is type=local')
 
     local used_local_path = false
     for _, call in ipairs(system_calls) do


### PR DESCRIPTION
Get rid of plenary using built in vim.net.request for async http calls.
Requires Neovim 0.12+

<img width="1919" height="1022" alt="image" src="https://github.com/user-attachments/assets/92257807-a578-4c12-aa35-4eadaa3263a2" />
<img width="1919" height="1018" alt="image" src="https://github.com/user-attachments/assets/140d8c80-fedd-4e28-bc88-01651f9d9329" />
<img width="1238" height="695" alt="image" src="https://github.com/user-attachments/assets/44458277-8886-42bd-9012-bc6125e1bfa8" />
<img width="1574" height="707" alt="image" src="https://github.com/user-attachments/assets/acecdbc9-05f0-4f68-83ab-4502a78034c4" />
<img width="1919" height="697" alt="image" src="https://github.com/user-attachments/assets/eba4f077-7f84-46e9-b50f-d21211b0d19e" />
<img width="1919" height="1014" alt="image" src="https://github.com/user-attachments/assets/4782d7e8-21cd-4452-8b67-29921139ad5d" />
<img width="1656" height="354" alt="image" src="https://github.com/user-attachments/assets/00afcdde-1bf8-47e5-94f0-285a3271368b" />
<img width="1919" height="1024" alt="image" src="https://github.com/user-attachments/assets/1537bfbf-0f0b-49e2-90f4-5b1f11db0f68" />

I'm under WinOS, so cannot run the test suite now; this may serve as a draft or reference for anybody that could test it more in depth with make test so we can get rid of plenary